### PR TITLE
Add syntax highlighting for fish and bqsql files, add eza dependency …

### DIFF
--- a/dot_config/fish/aliases.fish
+++ b/dot_config/fish/aliases.fish
@@ -12,4 +12,32 @@ abbr gl 'git pull'
 abbr gd 'git diff'
 abbr glog 'git log --oneline --decorate --graph'
 abbr c clear
-alias vim nvim
+abbr vim nvim
+
+# eza aliases (modern ls replacement)
+if command -v eza > /dev/null
+    alias ls 'eza --icons'
+    alias ll 'eza --long --icons'
+    alias la 'eza --all --icons'
+    alias lla 'eza --long --all --icons'
+    alias lt 'eza --tree --icons'
+    alias lta 'eza --tree --all --icons'
+    alias ltl 'eza --tree --long --icons'
+end
+
+# Common directory navigation aliases
+abbr .. 'cd ..'
+abbr ... 'cd ../..'
+abbr .... 'cd ../../..'
+
+# File operations
+abbr cp 'cp -i'
+abbr mv 'mv -i'
+abbr rm 'rm -i'
+
+# System aliases
+abbr df 'df -h'
+abbr du 'du -h'
+abbr free 'free -h'
+abbr ps 'ps aux'
+abbr grep 'grep --color=auto'

--- a/dot_config/nvim/lua/config/options.lua
+++ b/dot_config/nvim/lua/config/options.lua
@@ -21,3 +21,19 @@ vim.opt.updatetime = 50
 
 vim.opt.termguicolors = true
 vim.opt.clipboard = "unnamedplus"
+
+-- Filetype detection for bqsql files
+vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
+  pattern = { "*.bqsql", "*.bq" },
+  callback = function()
+    vim.bo.filetype = "sql"
+  end,
+})
+
+-- Filetype detection for fish files
+vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
+  pattern = { "*.fish" },
+  callback = function()
+    vim.bo.filetype = "fish"
+  end,
+})

--- a/dot_config/nvim/lua/plugins/treesitter.lua
+++ b/dot_config/nvim/lua/plugins/treesitter.lua
@@ -26,6 +26,8 @@ return {
           "markdown",
           "markdown_inline",
           "bash",
+          "fish",
+          "sql",
           "dockerfile",
           "gitignore",
         },

--- a/run_once_install_deps.sh
+++ b/run_once_install_deps.sh
@@ -14,6 +14,7 @@ packages=(
     "npm"
     "luarocks"
     "lazygit"
+    "eza"
 )
 
 # --- Script ---


### PR DESCRIPTION
…and aliases

- Add fish and sql parsers to treesitter for syntax highlighting
- Add filetype detection for .fish and .bqsql files
- Add eza as dependency in install script
- Add eza aliases and other sensible shell aliases